### PR TITLE
fix trim bug

### DIFF
--- a/github.js
+++ b/github.js
@@ -1,5 +1,5 @@
 const { Octokit } = require("@octokit/rest");
-const { githubToken, githubOrganization } = require("./vars");
+const { githubToken, githubOrganization } = require("./keys");
 const { log, success, info, error } = require("./util");
 const simpleGit = require("simple-git");
 const git = simpleGit();

--- a/keys.js
+++ b/keys.js
@@ -2,19 +2,20 @@ require("dotenv").config();
 
 // organization name, e.g. "greenelab"
 const githubOrganization =
-  (process.env.GITHUB_REPOSITORY || "").split("/")[0].trim() ||
-  process.env.GITHUB_ORGANIZATION.trim() ||
+  (process.env.GITHUB_REPOSITORY || "").split("/")[0] ||
+  process.env.GITHUB_ORGANIZATION ||
   "";
 
 // auth tokens
-const githubToken = process.env.GITHUB_TOKEN.trim() || "";
-const softwareHeritageToken = process.env.SOFTWARE_HERITAGE_TOKEN.trim() || "";
+const githubToken = process.env.GITHUB_TOKEN || "";
+const softwareHeritageToken = process.env.SOFTWARE_HERITAGE_TOKEN || "";
 
 // collect keys
 const keys = { githubOrganization, githubToken, softwareHeritageToken };
 
 // log keys
-for (const [key, value] of Object.entries(keys))
+for (const [key, value] of Object.entries(keys)) {
+  keys[key] = value.trim();
   console.log(`${key}: ${value.trim() ? `"...${value.slice(-4)}"` : `""`}`);
-
+}
 module.exports = keys;

--- a/software-heritage.js
+++ b/software-heritage.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const fetch = require("node-fetch");
-const { softwareHeritageToken } = require("./vars");
+const { softwareHeritageToken } = require("./keys");
 const { log, success, info, warning, error, sleep } = require("./util");
 
 // don't archive repo if last archived less than this many minutes ago


### PR DESCRIPTION
Fix bug where script crashes if there is no `GITHUB_TOKEN` environment variable. The script will still fail if this token is missing, but just further down the line in a more appropriate place. That variable should be set automatically by GitHub Actions when running the workflow, but it wasn't for some reason. I'm guessing (and hoping) this was due to the outage GitHub supposedly had over the weekend.